### PR TITLE
Adding Brackets to parameters when Adding

### DIFF
--- a/lib/awsCloudSearch.php
+++ b/lib/awsCloudSearch.php
@@ -77,7 +77,7 @@ class awsCloudSearch {
    */
 	
     private function call($url, $method, $parameters) {
-        
+        $parameters = "[".$parameters."]";
         $curl2 = curl_init();
         
         if ($method == "POST")


### PR DESCRIPTION
Brackets need to be added to the parameters before submitting amazon. If there are no brackets then amazon rejects the request.
